### PR TITLE
Let a single source fail gracefully and not break everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project follows [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Fixed
+- Show nice error message if jira fails (#51)
+- If one source fails, continue the command
 
 ## 0.6.0 - 2017-06-27
 ### Added

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -47,9 +47,8 @@ function run(program) {
 }
 
 function querySources(options, exitCallback) {
-    Async.parallel([
-        function(callback) {
-            // Google Calendar
+    Async.parallel(Async.reflectAll({
+        calendar: function(callback) {
             if (options.calendar) {
                 google_auth.getAuth(function(auth) {
                     if (_.isBoolean(options.calendar)) {
@@ -61,8 +60,7 @@ function querySources(options, exitCallback) {
                 callback(null, []);
             }
         },
-        function(callback) {
-            // Google Mail
+        mail: function(callback) {
             if (options.mail) {
                 google_auth.getAuth(function(auth) {
                     mail.listMessages(callback, auth, options);
@@ -71,16 +69,17 @@ function querySources(options, exitCallback) {
                 callback(null, []);
             }
         },
-        function(callback) {
+        slack: function(callback) {
             if (options.slack) {
                 slack_auth.getAuth(function(auth) {
                     slack.dailyStats(callback, auth, options);
                 });
             } else {
-                callback(null, []);
+                //callback(null, []);
+                callback("aaargh");
             }
         },
-        function(callback) {
+        logbot: function(callback) {
             if (options.logbot) {
                 slack_auth.getAuth(function(auth) {
                     logbot.getLogs(callback, auth, options);
@@ -89,7 +88,7 @@ function querySources(options, exitCallback) {
                 callback(null, []);
             }
         },
-        function(callback) {
+        jira: function(callback) {
             if (options.jira) {
                 jira_auth.getAuth(function(auth) {
                     jira.getActivities(callback, auth, options);
@@ -98,7 +97,7 @@ function querySources(options, exitCallback) {
                 callback(null, []);
             }
         },
-        function(callback) {
+        zebra: function(callback) {
             if (options.zebra) {
                 zebra_auth.getAuth(function(auth) {
                     zebra.getTimesheets(callback, auth, options);
@@ -107,14 +106,14 @@ function querySources(options, exitCallback) {
                 callback(null, []);
             }
         },
-        function(callback) {
+        git: function(callback) {
             if (options.git) {
                 git.getCommits(callback, options);
             } else {
                 callback(null, []);
             }
         },
-        function(callback) {
+        github: function(callback) {
             if (options.github) {
                 github_auth.getAuth(function(auth) {
                     github.getContributions(callback, auth, options);
@@ -123,10 +122,19 @@ function querySources(options, exitCallback) {
                 callback(null, []);
             }
         }
-    ],
-    function(err, results) {
-        results = _.flatten(results);
-        exitCallback(err, results);
+    }),
+    function(err, allResults) {
+        var results = [];
+
+        _.each(allResults, function(result, key) {
+            if (result.value) {
+                results = results.concat(result.value);
+            } else {
+                console.error('');
+                console.error(key + ' source failed with error: ' + result.error);
+            }
+        });
+        exitCallback(null, results);
     });
 }
 

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -45,6 +45,9 @@ Jira.prototype.getActivities = function(callback, auth, options) {
                 },
                 function(err, results) {
                     if (err) {
+                        if (err.message) {
+                            err = err.message;
+                        }
                         callback(err);
                     } else {
                         callback(null, _.flatten(results));
@@ -53,6 +56,9 @@ Jira.prototype.getActivities = function(callback, auth, options) {
             );
         })
         .catch(function(err) {
+            if (err.message) {
+                err = err.message;
+            }
             callback("The JIRA API returned an error: " + err);
         });
 };
@@ -60,7 +66,6 @@ Jira.prototype.getActivities = function(callback, auth, options) {
 Jira.prototype.generateDailyEntries = function(currentUser, startDate, endDate, verbose, callback) {
     return function(issue) {
         var project = issue.key.split('-')[0].toLowerCase();
-
 
         // filter changelog entries by the current user and in the defined time span
         helper.printVerbose("Issue " + issue.key + " changelog: [", verbose);

--- a/test/test.jira.js
+++ b/test/test.jira.js
@@ -192,5 +192,34 @@ describe('Jira', function() {
                 }
             }, auth, options);
         });
+        it('prints nice error message if JIRA fails', function(done) {
+            var currentUserStub = sandbox.stub(JiraApi.prototype, 'getCurrentUser')
+                .rejects({
+                    'name': 'StatusCodeError',
+                    'statusCode': 500,
+                    'message': '500 - {"errorMessages":["Internal server error"],"errors":{}}'
+                });
+
+
+            var options = {
+                'startDate': '2017-03-28',
+                'endDate': '2017-03-30',
+                'jira': true
+            };
+            var auth = {
+                'consumer_key': '123',
+                'consumer_secret': 'secret',
+                'access_token': '1234',
+                'access_token_secret': 'secret'
+            };
+            jira.getActivities(function(err, result) {
+                try {
+                    expect(err).to.equal('The JIRA API returned an error: 500 - {"errorMessages":["Internal server error"],"errors":{}}');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, auth, options);
+        });
    });
 });


### PR DESCRIPTION
By using Async.reflect each function in the Async.parallel block will
never fail, but instead have a .value or .error property in the result.

That way each source could fail without failing the whole command.