### PR TITLE
resolve deprecation issues

### DIFF
--- a/lib/source/github.js
+++ b/lib/source/github.js
@@ -204,7 +204,7 @@ class Github extends Source {
         var start = Moment(me.options.startDate).tz('Europe/Zurich');
         var end = Moment(me.options.endDate).tz('Europe/Zurich').add(1, 'd');
 
-        var activityPromise = gh.activity.getEventsForUser({
+        var activityPromise = gh.activity.listEventsForUser({
             username: username
         });
 

--- a/test/test.github.js
+++ b/test/test.github.js
@@ -42,7 +42,7 @@ describe('Github', function() {
                 'authenticate': Sinon.stub(),
                 'hasNextPage': Sinon.stub().returns(false),
                 'users': {'get': userStub},
-                'activity': {'getEventsForUser': eventStub}
+                'activity': {'listEventsForUser': eventStub}
             };
             var authStub = {
                 'getAuth': Sinon.stub().resolves('1234')
@@ -103,7 +103,7 @@ describe('Github', function() {
 
             var apiStub = { 
                 'authenticate': Sinon.stub(),
-                'activity': {'getEventsForUser': Sinon.stub()}
+                'activity': {'listEventsForUser': Sinon.stub()}
             };
             var authStub = {
                 'getAuth': Sinon.stub().resolves('1234')


### PR DESCRIPTION
Authentication for zebra and gitlab does no longer work with the current before-after-hook-Version.

With these changes the tests still succeed. It might make sense though, to rather pin the before-after-hook version as the function `activity.getEventsForUser()` is deprecated.

More details can be found here: https://git.io/upgrade-before-after-hook-to-1.4

What do you think?
